### PR TITLE
Updating 'create' and 'replicate'

### DIFF
--- a/CoreLibraryFunctions.md
+++ b/CoreLibraryFunctions.md
@@ -81,7 +81,7 @@ The proposal below is to complete the matrix for List, Array and Seq w.r.t. func
 | pick       |           |     o     |        o  |     o    |   ---       |     ---     |
 | reduce     |           |     o     |        o  |     o    |   ---       |     ---     |
 | reduceBack |           |    o      |         o |      ADD |          |          |
-| replicate  |           |     o    |    ADD    |   ADD    |          |          |
+| replicate  |   see note        |     o    |    ADD    |   ADD    |          |          |
 | rev        |           |    o      |   o       |    ADD   |          |          |
 | scan       |           |     o     |      o    |     o    | ---         |   ---       |
 | scanBack   |           |     o     |    o      |   ADD    |          |          |

--- a/CoreLibraryFunctions.md
+++ b/CoreLibraryFunctions.md
@@ -34,6 +34,7 @@ The proposal below is to complete the matrix for List, Array and Seq w.r.t. func
 | compareWith|           |  ADD      |     ADD   |     o    |          |          |
 | concat     |           |     o     |       o   |     o    |   ---       | ---         |
 | countBy    |           |  ADD      |     ADD   |      o   |          |          |
+| create     | See note          |   ADD     |      o    |    ADD   |          |          |
 | distinct   |           |   ADD     |     ADD   |     o    |          |          |
 | distinctBy |           |    ADD    |    ADD    |    o     |          |          |
 | empty      |           |    o      |    o      |      o   |   ---       |   ---       |
@@ -108,6 +109,9 @@ The proposal below is to complete the matrix for List, Array and Seq w.r.t. func
 | zip        |           |    o      |  o        |  o       |   ---       |   ---       |
 | zip3       |           |    o      |  o        |  o       |   ---       |   ---       |
 
+Note: ``Array.create`` and ``List.replicate`` have the same signature and serve the same purpose.  Given that
+both already exist, it seems sensible to complete the matrix and implement both ``create`` and ``replicate`` for all collection types.
+
 Note: In F# 3.0 Seq.where was defined as a synonym for Seq.filter, mainly due to the use of "where" in query expressions. Given
 it already  exists as a synonym (= decision made) it seems sensible to just complete the matrix and define List.where and Array.where as well.
 
@@ -136,7 +140,6 @@ These operators are not defined for Seq.* for performance reasons because using 
 |:-----------|:----------|:---------:|:---------:|:--------:|:--------:|:--------:|
 | blit       |           |     n/a   |   o       |   n/a    |          |          |
 | copy       |           |   n/a     |     o     |     n/a  |          |          |
-| create     |           |   n/a     |      o    |    n/a   |          |          |
 | fill       |           |   n/a     |     o     |     n/a  |          |          |
 | get        |           |    n/a    |     o     |  n/a     |          |          |
 | set        |           |    n/a    |   o       |    n/a   |          |          |


### PR DESCRIPTION
Existing functions ``Array.create`` and ``List.replicate`` do the same thing.  I moved ``create`` up to the main list of functions. How do we want to handle the duplication?

* Fill out the matrix, implement both ``create`` and ``replicate`` for all collection types (safest option)
* Pick one to endorse, deprecate the other (tough - I like the name ``replicate`` better, but my hunch is that ``Array.create`` is used more often)

I went with option 1 in this change.