### PR TITLE
Minor correction to cross definition

### DIFF
--- a/RFCs/FS-1002-cartesian-product-for-collections.md
+++ b/RFCs/FS-1002-cartesian-product-for-collections.md
@@ -31,7 +31,7 @@ let ys = [y1 .. yM]
 cross xs ys =
     [x1, y1; x1, y.; x1, yM;
      x., y1; x., y.; x., yM;
-     xN, yM; xN, y.; xN, yM]
+     xN, y1; xN, y.; xN, yM]
 ```
 
 ### Naming 


### PR DESCRIPTION
I believe `yM` should be `y1` - looks like a simple typo or maybe copy+paste error.